### PR TITLE
Correct fixed conf_thresh

### DIFF
--- a/samples/python/stitching_detailed.py
+++ b/samples/python/stitching_detailed.py
@@ -343,7 +343,7 @@ def main():
         with open(args.save_graph, 'w') as fh:
             fh.write(cv.detail.matchesGraphAsString(img_names, p, conf_thresh))
 
-    indices = cv.detail.leaveBiggestComponent(features, p, 0.3)
+    indices = cv.detail.leaveBiggestComponent(features, p, conf_thresh)
     img_subset = []
     img_names_subset = []
     full_img_sizes_subset = []


### PR DESCRIPTION
According to the documentation, [cv.detail.leaveBiggestComponent](https://docs.opencv.org/4.5.1/d7/d74/group__stitching__rotation.html#ga855d2fccbcfc3b3477b34d415be5e786) takes features, the pairwise_matches and the conf_threshold as input.
In the tutorial, however, conf_threshold is fixed at 0.3 even though the user can pass conf_thresh as parameter which is 1 by default. Fixing this parameter at 0.3 causes the script to include images into the panorama which are not part of it.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
